### PR TITLE
Removed unsafe

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -1,74 +1,73 @@
 package main
 
 import (
-    "fmt"
-    "math"
-    "math/rand/v2"
-    "time"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"time"
 
-    "github.com/kelindar/bench"
-    "github.com/kelindar/simplex"
+	"github.com/kelindar/bench"
+	"github.com/kelindar/simplex"
 )
 
 var sizes = []int{1e3, 1e6}
 
 func main() {
-    bench.Run(func(b *bench.B) {
-        runNoise(b)
-    }, bench.WithDuration(10*time.Millisecond), bench.WithSamples(100))
+	bench.Run(func(b *bench.B) {
+		runNoise(b)
+	}, bench.WithDuration(10*time.Millisecond), bench.WithSamples(100))
 }
 
 func runNoise(b *bench.B) {
-    shapes := []struct {
-        name string
-        gen  func(int) [][2]float32
-    }{
-        {"seq", dataSeq},
-        {"rnd", dataRand},
-        {"circ", dataCircle},
-    }
+	shapes := []struct {
+		name string
+		gen  func(int) [][2]float32
+	}{
+		{"seq", dataSeq},
+		{"rnd", dataRand},
+		{"circ", dataCircle},
+	}
 
-    for _, size := range sizes {
-        for _, shape := range shapes {
-            points := shape.gen(size)
-            name := fmt.Sprintf("noise %s (%s)", formatSize(size), shape.name)
-            b.Run(name, func(i int) {
-                p := points[i%len(points)]
-                _ = simplex.Noise2(p[0], p[1])
-            })
-        }
-    }
+	const size = 1000
+	for _, shape := range shapes {
+		points := shape.gen(size)
+		name := fmt.Sprintf("noise %s (%s)", formatSize(size), shape.name)
+		b.Run(name, func(i int) {
+			p := points[i%len(points)]
+			_ = simplex.Noise2(p[0], p[1])
+		})
+	}
 }
 
 func formatSize(size int) string {
-    if size >= 1e6 {
-        return fmt.Sprintf("%.0fM", float64(size)/1e6)
-    }
-    return fmt.Sprintf("%.0fK", float64(size)/1e3)
+	if size >= 1e6 {
+		return fmt.Sprintf("%.0fM", float64(size)/1e6)
+	}
+	return fmt.Sprintf("%.0fK", float64(size)/1e3)
 }
 
 func dataSeq(n int) [][2]float32 {
-    pts := make([][2]float32, n)
-    for i := 0; i < n; i++ {
-        f := float32(i)
-        pts[i] = [2]float32{f, f}
-    }
-    return pts
+	pts := make([][2]float32, n)
+	for i := 0; i < n; i++ {
+		f := float32(i)
+		pts[i] = [2]float32{f, f}
+	}
+	return pts
 }
 
 func dataRand(n int) [][2]float32 {
-    pts := make([][2]float32, n)
-    for i := 0; i < n; i++ {
-        pts[i] = [2]float32{rand.Float32(), rand.Float32()}
-    }
-    return pts
+	pts := make([][2]float32, n)
+	for i := 0; i < n; i++ {
+		pts[i] = [2]float32{rand.Float32(), rand.Float32()}
+	}
+	return pts
 }
 
 func dataCircle(n int) [][2]float32 {
-    pts := make([][2]float32, n)
-    for i := 0; i < n; i++ {
-        angle := 2 * math.Pi * float64(i) / float64(n)
-        pts[i] = [2]float32{float32(math.Cos(angle)), float32(math.Sin(angle))}
-    }
-    return pts
+	pts := make([][2]float32, n)
+	for i := 0; i < n; i++ {
+		angle := 2 * math.Pi * float64(i) / float64(n)
+		pts[i] = [2]float32{float32(math.Cos(angle)), float32(math.Sin(angle))}
+	}
+	return pts
 }


### PR DESCRIPTION
This pull request refactors the `simplex.go` implementation to remove unsafe pointer usage, replacing it with safer, direct indexing into arrays. Additionally, it simplifies the benchmarking logic in `bench/main.go` by fixing the input size for noise tests. These changes improve code safety, readability, and maintainability.

### Simplex noise implementation refactor

* Removed all use of `unsafe.Pointer` and related pointer arithmetic in `simplex.go`, eliminating the `pPerm` and `pGrad` variables and associated functions (`permutationsAt` and `gradientAt`). All array accesses are now done via safe indexing. [[1]](diffhunk://#diff-766b14459117ab60e36d6eddc8269300ed6008f0742e34484166036ae9899abaL3-L6) [[2]](diffhunk://#diff-766b14459117ab60e36d6eddc8269300ed6008f0742e34484166036ae9899abaL15-L16) [[3]](diffhunk://#diff-766b14459117ab60e36d6eddc8269300ed6008f0742e34484166036ae9899abaL53-L67)
* Updated the `Noise2` function to use direct array indexing for permutation and gradient lookup, with explicit bounds checks for the compiler.

### Benchmark logic simplification

* Changed the benchmarking loop in `bench/main.go` to use a fixed input size (`size = 1000`) for all shapes, instead of iterating over multiple sizes.
* Minor cleanup in `bench/main.go` by removing an unnecessary closing brace.