### PR TITLE
Refactor noise computation and update benchmark results in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ This respository contains an experimental implementation of [simplex noise](http
 
 ```
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkNoise/10x10-8       763042   1568 ns/op      0 B/op   0 allocs/op
-BenchmarkNoise/100x100-8     7402     159403 ns/op    0 B/op   0 allocs/op
-BenchmarkNoise/1000x1000-8   74       15732020 ns/op  0 B/op   0 allocs/op
+name                 time/op      ops/s        allocs/op   
+-------------------- ------------ ------------ ------------
+noise 1K (seq)       12.6 ns      79.4M        0           
+noise 1K (rnd)       15.5 ns      64.5M        0           
+noise 1K (circ)      14.8 ns      67.8M        0           
+
 ```
 
 ## Contributing


### PR DESCRIPTION
This pull request refactors the 2D simplex noise implementation for improved clarity and performance, particularly in how gradients are handled and accessed. The main changes include switching the gradient representation from packed integers to float arrays, updating the initialization logic, and simplifying the noise calculation code. Benchmark results in the `README.md` have also been updated to reflect new performance metrics.

**Gradient representation and initialization:**
* Changed the `grad` array from storing packed `uint16` values to storing `[2]float32` arrays, making the gradient vectors easier to use and understand.
* Updated the gradient initialization in `init()` to unpack and store gradients directly as float pairs, improving clarity and reducing bit manipulation.

**Noise computation simplification:**
* Refactored the `Noise2` function to use float values for simplex triangle selection and offsets, streamlining the calculation and reducing unnecessary type conversions.
* Simplified the lookup and use of permutation and gradient arrays by using slice windows and direct array access, making the code more readable and efficient.
* Inlined the dot product calculation for gradients, removing the need for a separate `dot2D` function and improving performance.

**Benchmark update:**
* Updated the benchmark section in `README.md` to show new performance results with more descriptive labels, reflecting the impact of the code changes.