### PR TITLE
Simplify gradient calc

### DIFF
--- a/simplex.go
+++ b/simplex.go
@@ -10,7 +10,7 @@ var (
 	grad [512][2]float32
 )
 
-var table = []uint8{151, 160, 137, 91, 90, 15,
+var table = [...]uint8{151, 160, 137, 91, 90, 15,
 	131, 13, 201, 95, 96, 53, 194, 233, 7, 225, 140, 36, 103, 30, 69, 142, 8, 99, 37, 240, 21, 10, 23,
 	190, 6, 148, 247, 120, 234, 75, 0, 26, 197, 62, 94, 252, 219, 203, 117, 35, 11, 32, 57, 177, 33,
 	88, 237, 149, 56, 87, 174, 20, 125, 136, 171, 168, 68, 175, 74, 165, 71, 134, 139, 48, 27, 166,
@@ -82,18 +82,14 @@ func Noise2(x, y float32) float32 {
 	y2 := y0 - 1 + g
 
 	// Work out the hashed gradient indices of the three simplex corners
-	ii := int(i & 255)
-	jj := int(j & 255)
-
-	// Use slice windows
-	pp := perm[jj:]
-	gg := grad[ii:]
-	p0 := int(pp[0])
-	p1 := int(pp[int(j1)])
-	p2 := int(pp[1])
-	g0 := gg[p0]
-	g1 := gg[int(i1)+p1]
-	g2 := gg[1+p2]
+	ii := uint8(i & 255)
+	jj := uint8(j & 255)
+	p0 := uint8(perm[jj])
+	p1 := uint8(perm[jj+uint8(j1)])
+	p2 := uint8(perm[jj+1])
+	g0 := grad[ii+p0]
+	g1 := grad[ii+uint8(i1)+p1]
+	g2 := grad[ii+1+p2]
 
 	// Calculate the contribution from the three corners
 	n := float32(0.0)
@@ -115,15 +111,7 @@ func Noise2(x, y float32) float32 {
 // pow4 lifts the value to the power of 4
 func pow4(v float32) float32 {
 	v *= v
-	v *= v
-	return v
-}
-
-// dot2D computes dot product with the gradient
-func dot2D(g uint16, x, y float32) float32 {
-	gx := float32(int8(g >> 8))
-	gy := float32(int8(g))
-	return gx*x + gy*y
+	return v * v
 }
 
 // floor floors the floating-point value to an integer

--- a/simplex_test.go
+++ b/simplex_test.go
@@ -39,26 +39,6 @@ func BenchmarkNoise(b *testing.B) {
 	assert.NotZero(b, out)
 }
 
-/*
-cpu: 13th Gen Intel(R) Core(TM) i7-13700K
-BenchmarkDot/2d-24 	48869684	        24.60 ns/op	       0 B/op	       0 allocs/op
-*/
-func BenchmarkDot(b *testing.B) {
-	var out float32
-	b.Run("2d", func(b *testing.B) {
-		b.ReportAllocs()
-		b.ResetTimer()
-
-		for n := 0; n < b.N; n++ {
-			for i := uint8(0); i < 100; i++ {
-				out = dot2D(0xffff, 10, 20)
-			}
-		}
-	})
-
-	assert.NotZero(b, out)
-}
-
 func TestSimplex_500x500(t *testing.T) {
 	n := 500
 	freq := float32(25)


### PR DESCRIPTION
This pull request refactors parts of the `simplex.go` implementation to simplify indexing logic and remove unused code, resulting in a cleaner and slightly more efficient codebase. The main changes include updating index types and access patterns in the noise generation function, removing the unused `dot2D` function, and deleting its associated benchmark.

Refactoring and simplification of indexing logic:

* Updated index types and access patterns in `Noise2` to use `uint8` for indices and direct indexing for `perm` and `grad`, replacing slice windows and type conversions for improved clarity and performance. (`simplex.go`, [simplex.goL85-R92](diffhunk://#diff-766b14459117ab60e36d6eddc8269300ed6008f0742e34484166036ae9899abaL85-R92))
* Changed the declaration of `table` from a slice to an array for better type safety. (`simplex.go`, [simplex.goL13-R13](diffhunk://#diff-766b14459117ab60e36d6eddc8269300ed6008f0742e34484166036ae9899abaL13-R13))

Code cleanup:

* Removed the unused `dot2D` function, eliminating dead code from the codebase. (`simplex.go`, [simplex.goL118-R114](diffhunk://#diff-766b14459117ab60e36d6eddc8269300ed6008f0742e34484166036ae9899abaL118-R114))
* Deleted the `BenchmarkDot` benchmark and its related comments, as it is no longer relevant after removing `dot2D`. (`simplex_test.go`, [simplex_test.goL42-L61](diffhunk://#diff-32b68853de63223775ae7a82d71721d272fec16c84bdc7772c9d353206fde4c1L42-L61))

Minor math simplification:

* Simplified the `pow4` function by removing redundant lines and returning the result directly. (`simplex.go`, [simplex.goL118-R114](diffhunk://#diff-766b14459117ab60e36d6eddc8269300ed6008f0742e34484166036ae9899abaL118-R114))